### PR TITLE
FolderHandler ext3/4 sorting

### DIFF
--- a/resources/lib/audiobook.py
+++ b/resources/lib/audiobook.py
@@ -537,6 +537,7 @@ class FolderHandler(AudioBookHandler):
     def _loadSpecificDetails(self, includeCover=True):
         # List all the files in the directory, as that will be the chapters
         dirs, files = xbmcvfs.listdir(self.filePath)
+        files.sort()
 
         # Check if the cover image is required
         coverTargetName = None


### PR DESCRIPTION
Function listdir gets files in order like ls -f command (in order in which files was placed to file system). 
It would be fine to sort them by name by default